### PR TITLE
Add `FinderSupportsInterface` for conditional finders

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,10 +1,12 @@
 name: "CI"
 
 on:
-  pull_request:
   push:
     branches:
-      - 'main'
+      - 'master'
+  pull_request:
+    branches:
+      - 'master'
   schedule:
     -   cron: '0 0 * * 0'
 
@@ -82,15 +84,15 @@ jobs:
           - '8.0'
         symfony-version:
           - '4.4.*'
-          - '5.3.*'
-          - '5.4.x-dev'
-          - '6.0.x-dev'
+          - '5.4.x'
+          - '6.0.x'
+          - '6.3.x-dev'
         dependency-versions: ['highest']
         allow-dev-deps-in-apps: ['0']
         include:
           # testing lowest php version with highest 5.x stable
           - php-version: '7.4'
-            symfony-version: '5.3.*'
+            symfony-version: '5.4.*'
             dependency-versions: 'lowest'
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 /tests/tmp/*
 /.php_cs.cache
 /.phpunit.result.cache
+/tests/fixtures/php-cs-fixer/vendor/
+/tests/fixtures/php-cs-fixer/composer.lock
+/.php-cs-fixer.cache

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ JsonApiBundle is a [Symfony][1] bundle. It is the fastest way to generate API ba
     ```
     for example, Book and Author entity is as follows:
     ```php
+    use Doctrine\ORM\Mapping as ORM;
     class Book
     {
         /**
@@ -70,6 +71,8 @@ JsonApiBundle is a [Symfony][1] bundle. It is the fastest way to generate API ba
         ... 
     ```
     ```php
+    use Doctrine\ORM\Mapping as ORM;
+    use Symfony\Component\Validator\Constraints as Assert;
     class Author
     {
         /**
@@ -148,7 +151,9 @@ http://example.com/books?filter[title]=%php%&filter[authors.name]=hamid%
 #### Setting a default filter on the IndexAction
 By using ```$resourceCollection->getQuery()``` you can get access on the query object.
 use "r" alias for referring to the current entity. in this example the "r" refers to the "ProjectEntity"
+
 ```php
+use Symfony\Component\Routing\Annotation\Route;
 class ProjectController extends Controller
 {
     /**
@@ -169,7 +174,7 @@ class ProjectController extends Controller
 ```
 
 #### Other Finders
-Currently the following Finders are available via other bundles:
+Currently, the following Finders are available via other bundles:
 
 - [mnugter/jsonapi-rql-finder-bundle][7] - [RQL][8] based Finder
 
@@ -180,13 +185,40 @@ A Finder can be registered via a service tag in the services definition. The tag
 added to the service for the Finder to be resigered.
 
 Example:
-```
+```xml
 <service class="Paknahad\JsonApiBundle\Helper\Filter\Finder" id="paknahad_json_api.helper_filter.finder">
     <tag name="paknahad.json_api.finder" />
 </service>
 ```
 
-Each Finder must implement the `Paknahad\JsonApiBundle\Helper\Filter\FinderInterface` interface.
+Each Finder must implement the `Paknahad\JsonApiBundle\Helper\Filter\FinderInterface` interface. Take a look at
+`\Paknahad\JsonApiBundle\Helper\Filter\Finder` for an implementation example.
+
+If you need more control over the finders, you can instead use `\Paknahad\JsonApiBundle\Helper\Filter\FinderSupportsInterface`
+interface and implement conditional logic inside `supports()` method:
+```php
+use Paknahad\JsonApiBundle\Helper\Filter\FinderSupportsInterface;
+use Paknahad\JsonApiBundle\Helper\FieldManager;
+use Symfony\Component\HttpFoundation\Request;
+
+class CustomFinder implements FinderSupportsInterface
+{
+    public function supports(Request $request, FieldManager $fieldManager): bool
+    {
+        // based on some request data
+        if ($request->query->has('some-flag')) {
+            return true;
+        }
+
+        // based on document field manager
+        if ($fieldManager->getRootEntity() === Author::class) {
+            return true;
+        }
+
+        return false;
+    }
+}
+```
 
 ### Validation
 

--- a/src/Helper/Filter/FinderCollection.php
+++ b/src/Helper/Filter/FinderCollection.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation\Request;
 class FinderCollection
 {
     /**
-     * @var FinderInterface[]
+     * @var iterable<FinderInterface>
      */
     private $handlers;
 
@@ -24,12 +24,13 @@ class FinderCollection
         $this->handlers = $handlers;
     }
 
-    /**
-     * @throws \Doctrine\ORM\EntityNotFoundException
-     */
     public function handleQuery(QueryBuilder $query, Request $request, FieldManager $fieldManager): void
     {
         foreach ($this->handlers as $handler) {
+            if ($handler instanceof FinderSupportsInterface && !$handler->supports($request, $fieldManager)) {
+                continue;
+            }
+
             $handler->setRequest($request);
             $handler->setQuery($query);
             $handler->setFieldManager($fieldManager);

--- a/src/Helper/Filter/FinderSupportsInterface.php
+++ b/src/Helper/Filter/FinderSupportsInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Paknahad\JsonApiBundle\Helper\Filter;
+
+use Paknahad\JsonApiBundle\Helper\FieldManager;
+use Symfony\Component\HttpFoundation\Request;
+
+interface FinderSupportsInterface extends FinderInterface
+{
+    /**
+     * Whether this finder can operate with the giver Request and FieldManager.
+     */
+    public function supports(Request $request, FieldManager $fieldManager): bool;
+}


### PR DESCRIPTION
I have a use case, where I want to split finders based on the entity. Currently, I've to add some logic to `filterQuery()` and `sortQuery()` to check whether the request should be processed or not.

Adding a new method `supports()` simplifies the code and adds more control.